### PR TITLE
Add diagram for bookstore

### DIFF
--- a/solutions/Bookstore/diagrams/Checkout.bpmn
+++ b/solutions/Bookstore/diagrams/Checkout.bpmn
@@ -1,0 +1,675 @@
+<?xml version="1.0" encoding="UTF-8"?>
+    <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.8.0">
+        <bpmn:collaboration id="Collaboration_1cidyxu" name="">
+            <bpmn:extensionElements>
+                <camunda:executionListener class="" event="" />
+                <camunda:properties />
+            </bpmn:extensionElements>
+            <bpmn:participant id="Participant_0px403d" name="Checkout" processRef="Checkout (1)">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+            </bpmn:participant>
+        </bpmn:collaboration>
+        <bpmn:process id="Checkout (1)" name="Checkout" isExecutable="false">
+            <bpmn:laneSet>
+                <bpmn:lane id="Lane_1xzf0d3" name="Lane">
+                    <bpmn:extensionElements>
+                        <camunda:executionListener class="" event="" />
+                        <camunda:properties />
+                    </bpmn:extensionElements>
+                    <bpmn:flowNodeRef>
+                        StartEvent_1
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        ExclusiveGateway_0goz1dp
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        eingabeKorrekt
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        adresse_formular
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        UserTask_0psue0p
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        Task_0wda4e2
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        buecherliste
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        rechnung
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        EndEvent_0tb2uqt
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        ExclusiveGateway_1yumraf
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        UserTask_1ha23z3
+                    </bpmn:flowNodeRef>
+                    <bpmn:flowNodeRef>
+                        UserTask_1oi8pr5
+                    </bpmn:flowNodeRef>
+                    <bpmn:childLaneSet>
+                        <bpmn:lane id="Lane_1rrhdbm" name="">
+                            <bpmn:extensionElements>
+                                <camunda:executionListener class="" event="" />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                            </bpmn:extensionElements>
+                            <bpmn:flowNodeRef>
+                                StartEvent_1
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                ExclusiveGateway_0goz1dp
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                eingabeKorrekt
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                adresse_formular
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                UserTask_0psue0p
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                Task_0wda4e2
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                buecherliste
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                EndEvent_0tb2uqt
+                            </bpmn:flowNodeRef>
+                        </bpmn:lane>
+                        <bpmn:lane id="Lane_092xula" name="">
+                            <bpmn:extensionElements>
+                                <camunda:executionListener class="" event="" />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                                <camunda:properties />
+                            </bpmn:extensionElements>
+                            <bpmn:flowNodeRef>
+                                rechnung
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                ExclusiveGateway_1yumraf
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                UserTask_1ha23z3
+                            </bpmn:flowNodeRef>
+                            <bpmn:flowNodeRef>
+                                UserTask_1oi8pr5
+                            </bpmn:flowNodeRef>
+                        </bpmn:lane>
+                    </bpmn:childLaneSet>
+                </bpmn:lane>
+            </bpmn:laneSet>
+            <bpmn:startEvent id="StartEvent_1" name="Checkout">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+                <bpmn:outgoing>
+                    SequenceFlow_0s2dby5
+                </bpmn:outgoing>
+            </bpmn:startEvent>
+            <bpmn:sequenceFlow id="SequenceFlow_0ebs0gy" name="" sourceRef="Task_0wda4e2" targetRef="adresse_formular">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+            </bpmn:sequenceFlow>
+            <bpmn:sequenceFlow id="SequenceFlow_0f0cs2x" name="" sourceRef="adresse_formular" targetRef="eingabeKorrekt">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+            </bpmn:sequenceFlow>
+            <bpmn:exclusiveGateway id="ExclusiveGateway_0goz1dp" name="Eingaben korrekt?">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+                <bpmn:incoming>
+                    SequenceFlow_1psb8tw
+                </bpmn:incoming>
+                <bpmn:outgoing>
+                    SequenceFlow_0jtv6yo
+                </bpmn:outgoing>
+                <bpmn:outgoing>
+                    SequenceFlow_0518bg7
+                </bpmn:outgoing>
+            </bpmn:exclusiveGateway>
+            <bpmn:sequenceFlow id="SequenceFlow_0jtv6yo" name="Eingabe korrekt" sourceRef="ExclusiveGateway_0goz1dp" targetRef="rechnung">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+                <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">
+                    (Array.isArray(token.history.eingabeKorrekt)? token.history.eingabeKorrekt[token.history.eingabeKorrekt.length-1] === true: token.history.eingabeKorrekt === true)
+                </bpmn:conditionExpression>
+            </bpmn:sequenceFlow>
+            <bpmn:sequenceFlow id="SequenceFlow_0518bg7" name="Eingabe fehlerhaft" sourceRef="ExclusiveGateway_0goz1dp" targetRef="UserTask_0psue0p">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+                <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">
+                    (Array.isArray(token.history.eingabeKorrekt)? token.history.eingabeKorrekt[token.history.eingabeKorrekt.length-1] === false: token.history.eingabeKorrekt === false)
+                </bpmn:conditionExpression>
+            </bpmn:sequenceFlow>
+            <bpmn:sequenceFlow id="SequenceFlow_1psb8tw" sourceRef="eingabeKorrekt" targetRef="ExclusiveGateway_0goz1dp" />
+            <bpmn:scriptTask id="eingabeKorrekt" name="Eingaben kontrollieren">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+                <bpmn:incoming>
+                    SequenceFlow_0f0cs2x
+                </bpmn:incoming>
+                <bpmn:outgoing>
+                    SequenceFlow_1psb8tw
+                </bpmn:outgoing>
+                <bpmn:script>
+                    return !!(token.current.hausnummer.match(/^[0-9]{1,3}[A-Z]?$/))
+                </bpmn:script>
+            </bpmn:scriptTask>
+            <bpmn:userTask id="adresse_formular" name="Adresse eingeben">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties>
+                        <camunda:property name="uiName" value="Form" />
+                    </camunda:properties>
+                    <camunda:formData>
+                        <camunda:formField id="adresse" label="Straße" type="string" defaultValue="" />
+                        <camunda:formField id="hausnummer" label="Hausnummer" type="string" defaultValue="" />
+                    </camunda:formData>
+                </bpmn:extensionElements>
+                <bpmn:incoming>
+                    SequenceFlow_0ebs0gy
+                </bpmn:incoming>
+                <bpmn:incoming>
+                    SequenceFlow_0fz0ydc
+                </bpmn:incoming>
+                <bpmn:outgoing>
+                    SequenceFlow_0f0cs2x
+                </bpmn:outgoing>
+            </bpmn:userTask>
+            <bpmn:userTask id="UserTask_0psue0p" name="Fehler anzeigen">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties>
+                        <camunda:property name="uiName" value="Confirm" />
+                        <camunda:property name="uiConfig" value="${ &#34;message&#34;: &#34;FEHLER: Hausnummer müssen mit max. 3 Ziffern beginnen. Sie dürfen mit einem großen Buchstaben enden. Bitte geben Sie die Daten erneut ein.&#34;, &#34;layout&#34;: [ { &#34;key&#34;: &#34;confirm&#34;, &#34;label&#34;: &#34;OK&#34; } ] };" />
+                    </camunda:properties>
+                </bpmn:extensionElements>
+                <bpmn:incoming>
+                    SequenceFlow_0518bg7
+                </bpmn:incoming>
+                <bpmn:outgoing>
+                    SequenceFlow_0fz0ydc
+                </bpmn:outgoing>
+            </bpmn:userTask>
+            <bpmn:sequenceFlow id="SequenceFlow_0fz0ydc" sourceRef="UserTask_0psue0p" targetRef="adresse_formular" />
+            <bpmn:userTask id="Task_0wda4e2" name="Warenkorb überprüfen">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties>
+                        <camunda:property name="uiName" value="Confirm" />
+                        <camunda:property name="uiConfig" value="${ &#34;message&#34;: &#39;Folgende Bücher sind im Warenkorb: &#60;br/&#62; &#39; + token.current.map((entry)=&#62;(&#39;Titel: &#39; + entry.name + &#39;&#60;br/&#62; Preis: &#39; + entry.price + &#39;€ &#60;br/&#62; &#60;br/&#62;&#39;)), &#34;layout&#34;: [ { &#34;key&#34;: &#34;confirm&#34;, &#34;label&#34;: &#34;OK&#34; } ] };" />
+                    </camunda:properties>
+                </bpmn:extensionElements>
+                <bpmn:incoming>
+                    SequenceFlow_1ef2ox0
+                </bpmn:incoming>
+                <bpmn:outgoing>
+                    SequenceFlow_0ebs0gy
+                </bpmn:outgoing>
+            </bpmn:userTask>
+            <bpmn:sequenceFlow id="SequenceFlow_0s2dby5" sourceRef="StartEvent_1" targetRef="buecherliste" />
+            <bpmn:scriptTask id="buecherliste" name="Erstelle Bücherliste">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+                <bpmn:incoming>
+                    SequenceFlow_0s2dby5
+                </bpmn:incoming>
+                <bpmn:outgoing>
+                    SequenceFlow_1ef2ox0
+                </bpmn:outgoing>
+                <bpmn:script>
+                    <![CDATA[return [{name: 'Structure and Interpretation of Computer Programs',price: 50,}, {name: 'Decamerone',price: 30,}, {name: 'Guards! Guards!',price: 25}];]]>
+                </bpmn:script>
+            </bpmn:scriptTask>
+            <bpmn:sequenceFlow id="SequenceFlow_1ef2ox0" sourceRef="buecherliste" targetRef="Task_0wda4e2" />
+            <bpmn:scriptTask id="rechnung" name="Berechne Preis">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+                <bpmn:incoming>
+                    SequenceFlow_0jtv6yo
+                </bpmn:incoming>
+                <bpmn:outgoing>
+                    SequenceFlow_1ty02so
+                </bpmn:outgoing>
+                <bpmn:script>
+                    <![CDATA[return (token.history.buecherliste.reduce(((acc, current) =>
+                    
+                     acc + current.price),0))]]>
+                </bpmn:script>
+            </bpmn:scriptTask>
+            <bpmn:sequenceFlow id="SequenceFlow_1ty02so" sourceRef="rechnung" targetRef="ExclusiveGateway_1yumraf" />
+            <bpmn:endEvent id="EndEvent_0tb2uqt" name="">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+                <bpmn:incoming>
+                    SequenceFlow_0gpfpwx
+                </bpmn:incoming>
+            </bpmn:endEvent>
+            <bpmn:sequenceFlow id="SequenceFlow_0gpfpwx" sourceRef="UserTask_1ha23z3" targetRef="EndEvent_0tb2uqt" />
+            <bpmn:exclusiveGateway id="ExclusiveGateway_1yumraf" name="mehr als 100€ ?">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties />
+                </bpmn:extensionElements>
+                <bpmn:incoming>
+                    SequenceFlow_1ty02so
+                </bpmn:incoming>
+                <bpmn:outgoing>
+                    SequenceFlow_0a5begm
+                </bpmn:outgoing>
+                <bpmn:outgoing>
+                    SequenceFlow_1g16cx1
+                </bpmn:outgoing>
+            </bpmn:exclusiveGateway>
+            <bpmn:sequenceFlow id="SequenceFlow_0a5begm" name="weniger" sourceRef="ExclusiveGateway_1yumraf" targetRef="UserTask_1ha23z3">
+                <bpmn:extensionElements>
+                    <camunda:executionListener class="" event="" />
+                    <camunda:properties />
+                    <camunda:properties>
+                        <camunda:property name="mapper" value="{rechnung: token.history.rechnung}" />
+                    </camunda:properties>
+                </bpmn:extensionElements>
+                <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">
+                    <![CDATA[(token.history.rechnung <= 100)]]>
+                    </bpmn:conditionExpression>
+                </bpmn:sequenceFlow>
+                <bpmn:userTask id="UserTask_1ha23z3" name="Zeige Rechnung">
+                    <bpmn:extensionElements>
+                        <camunda:executionListener class="" event="" />
+                        <camunda:properties />
+                        <camunda:properties />
+                        <camunda:properties />
+                        <camunda:properties />
+                        <camunda:properties>
+                            <camunda:property name="uiName" value="Confirm" />
+                            <camunda:property name="uiConfig" value="${ &#34;message&#34;: &#34;Die Rechnung beträgt: &#34; + token.current.rechnung + &#34;€.&#34;, &#34;layout&#34;: [ { &#34;key&#34;: &#34;confirm&#34;, &#34;label&#34;: &#34;OK&#34; } ] };" />
+                        </camunda:properties>
+                        <camunda:formData />
+                    </bpmn:extensionElements>
+                    <bpmn:incoming>
+                        SequenceFlow_0a5begm
+                    </bpmn:incoming>
+                    <bpmn:incoming>
+                        SequenceFlow_1a7ytcq
+                    </bpmn:incoming>
+                    <bpmn:outgoing>
+                        SequenceFlow_0gpfpwx
+                    </bpmn:outgoing>
+                </bpmn:userTask>
+                <bpmn:userTask id="UserTask_1oi8pr5" name="Zeige Rechnung">
+                    <bpmn:extensionElements>
+                        <camunda:executionListener class="" event="" />
+                        <camunda:properties />
+                        <camunda:properties />
+                        <camunda:properties />
+                        <camunda:properties />
+                        <camunda:properties>
+                            <camunda:property name="uiName" value="Confirm" />
+                            <camunda:property name="uiConfig" value="${ &#34;message&#34;: &#34;Das hier sollte SMS verschicken, tut es aber (noch) nicht&#34;, &#34;layout&#34;: [ { &#34;key&#34;: &#34;confirm&#34;, &#34;label&#34;: &#34;OK&#34; } ] };" />
+                        </camunda:properties>
+                    </bpmn:extensionElements>
+                    <bpmn:incoming>
+                        SequenceFlow_1g16cx1
+                    </bpmn:incoming>
+                    <bpmn:outgoing>
+                        SequenceFlow_1a7ytcq
+                    </bpmn:outgoing>
+                </bpmn:userTask>
+                <bpmn:sequenceFlow id="SequenceFlow_1g16cx1" name="mehr" sourceRef="ExclusiveGateway_1yumraf" targetRef="UserTask_1oi8pr5">
+                    <bpmn:extensionElements>
+                        <camunda:executionListener class="" event="" />
+                        <camunda:properties />
+                        <camunda:properties />
+                    </bpmn:extensionElements>
+                    <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">
+                        <![CDATA[(token.history.rechnung >
+                                                100)]]>
+                    </bpmn:conditionExpression>
+                </bpmn:sequenceFlow>
+                <bpmn:sequenceFlow id="SequenceFlow_1a7ytcq" name="" sourceRef="UserTask_1oi8pr5" targetRef="UserTask_1ha23z3">
+                    <bpmn:extensionElements>
+                        <camunda:executionListener class="" event="" />
+                        <camunda:properties />
+                        <camunda:properties>
+                            <camunda:property name="mapper" value="{rechnung: token.history.rechnung}" />
+                        </camunda:properties>
+                    </bpmn:extensionElements>
+                </bpmn:sequenceFlow>
+            </bpmn:process>
+            <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+                <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+                    <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+                        <dc:Bounds x="-18" y="4" width="1662" height="625" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+                        <dc:Bounds x="101" y="65" width="36" height="36" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="109" y="101" width="21" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+                        <dc:Bounds x="12" y="4" width="1632" height="625" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNShape id="UserTask_1bbsjf6_di" bpmnElement="Task_0wda4e2">
+                        <dc:Bounds x="349" y="43" width="100" height="80" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNEdge id="SequenceFlow_0ebs0gy_di" bpmnElement="SequenceFlow_0ebs0gy">
+                        <di:waypoint x="449" y="83" />
+                        <di:waypoint x="516" y="83" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="437.5" y="61.5" width="90" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNShape id="UserTask_0585j05_di" bpmnElement="adresse_formular">
+                        <dc:Bounds x="516" y="43" width="100" height="80" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNShape id="ExclusiveGateway_0goz1dp_di" bpmnElement="ExclusiveGateway_0goz1dp" isMarkerVisible="true">
+                        <dc:Bounds x="804" y="58" width="50" height="50" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="784" y="111" width="90" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNShape id="Lane_1rrhdbm_di" bpmnElement="Lane_1rrhdbm">
+                        <dc:Bounds x="42" y="4" width="1602" height="267" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNShape id="Lane_092xula_di" bpmnElement="Lane_092xula">
+                        <dc:Bounds x="42" y="271" width="1602" height="358" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNEdge id="SequenceFlow_0f0cs2x_di" bpmnElement="SequenceFlow_0f0cs2x">
+                        <di:waypoint x="616" y="83" />
+                        <di:waypoint x="661" y="83" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="593.5" y="61.5" width="90" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNShape id="ScriptTask_17mfw10_di" bpmnElement="eingabeKorrekt">
+                        <dc:Bounds x="661" y="43" width="100" height="80" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNEdge id="SequenceFlow_0jtv6yo_di" bpmnElement="SequenceFlow_0jtv6yo">
+                        <di:waypoint x="854" y="83" />
+                        <di:waypoint x="1022" y="83" />
+                        <di:waypoint x="1022" y="340" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="892.2597296113818" y="61.34101520936346" width="78" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNEdge id="SequenceFlow_0518bg7_di" bpmnElement="SequenceFlow_0518bg7">
+                        <di:waypoint x="829" y="108" />
+                        <di:waypoint x="829" y="201" />
+                        <di:waypoint x="616" y="201" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="685" y="182" width="90" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNShape id="UserTask_0psue0p_di" bpmnElement="UserTask_0psue0p">
+                        <dc:Bounds x="516" y="161" width="100" height="80" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNEdge id="SequenceFlow_1psb8tw_di" bpmnElement="SequenceFlow_1psb8tw">
+                        <di:waypoint x="761" y="83" />
+                        <di:waypoint x="804" y="83" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="737.5" y="61.5" width="90" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNEdge id="SequenceFlow_0fz0ydc_di" bpmnElement="SequenceFlow_0fz0ydc">
+                        <di:waypoint x="566" y="161" />
+                        <di:waypoint x="566" y="123" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="581" y="135" width="0" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNEdge id="SequenceFlow_0s2dby5_di" bpmnElement="SequenceFlow_0s2dby5">
+                        <di:waypoint x="137" y="83" />
+                        <di:waypoint x="192" y="83" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="164.5" y="61.5" width="0" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNShape id="ScriptTask_0kyzdlj_di" bpmnElement="buecherliste">
+                        <dc:Bounds x="192" y="43" width="100" height="80" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNEdge id="SequenceFlow_1ef2ox0_di" bpmnElement="SequenceFlow_1ef2ox0">
+                        <di:waypoint x="292" y="83" />
+                        <di:waypoint x="349" y="83" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="275.5" y="61.5" width="90" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNShape id="ScriptTask_0r66a1m_di" bpmnElement="rechnung">
+                        <dc:Bounds x="964" y="340" width="100" height="80" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNShape id="UserTask_1ha23z3_di" bpmnElement="UserTask_1ha23z3">
+                        <dc:Bounds x="1320" y="340" width="100" height="80" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNEdge id="SequenceFlow_1ty02so_di" bpmnElement="SequenceFlow_1ty02so">
+                        <di:waypoint x="1064" y="380" />
+                        <di:waypoint x="1120" y="380" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="1047" y="358.5" width="90" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNShape id="EndEvent_0tb2uqt_di" bpmnElement="EndEvent_0tb2uqt">
+                        <dc:Bounds x="1448.1985428051003" y="119.63387978142077" width="36" height="36" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="1466.1985428051003" y="158.63387978142077" width="0" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNEdge id="SequenceFlow_0gpfpwx_di" bpmnElement="SequenceFlow_0gpfpwx">
+                        <di:waypoint x="1370" y="340" />
+                        <di:waypoint x="1370" y="138" />
+                        <di:waypoint x="1448" y="138" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="1340" y="232.5" width="90" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNShape id="ExclusiveGateway_1yumraf_di" bpmnElement="ExclusiveGateway_1yumraf" isMarkerVisible="true">
+                        <dc:Bounds x="1119.8132678132679" y="355" width="50" height="50" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="1113" y="333" width="79" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNEdge id="SequenceFlow_0a5begm_di" bpmnElement="SequenceFlow_0a5begm">
+                        <di:waypoint x="1169.8132678132679" y="380" />
+                        <di:waypoint x="1320" y="380" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="1226" y="359" width="39" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNShape id="UserTask_1oi8pr5_di" bpmnElement="UserTask_1oi8pr5">
+                        <dc:Bounds x="1095" y="469" width="100" height="80" />
+                    </bpmndi:BPMNShape>
+                    <bpmndi:BPMNEdge id="SequenceFlow_1g16cx1_di" bpmnElement="SequenceFlow_1g16cx1">
+                        <di:waypoint x="1145" y="405" />
+                        <di:waypoint x="1145" y="469" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="1147" y="430" width="26" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                    <bpmndi:BPMNEdge id="SequenceFlow_1a7ytcq_di" bpmnElement="SequenceFlow_1a7ytcq">
+                        <di:waypoint x="1195" y="509" />
+                        <di:waypoint x="1370" y="509" />
+                        <di:waypoint x="1370" y="420" />
+                        <bpmndi:BPMNLabel>
+                            <dc:Bounds x="1282.5" y="487.5" width="0" height="13" />
+                        </bpmndi:BPMNLabel>
+                    </bpmndi:BPMNEdge>
+                </bpmndi:BPMNPlane>
+            </bpmndi:BPMNDiagram>
+        </bpmn:definitions>


### PR DESCRIPTION
This diagram is supposed to be used in enterJS for demonstration.
Logic is based on script tasks, diagram works as a standalone.

Looks like that as of now:
<img width="828" alt="screen shot 2018-06-12 at 20 08 02" src="https://user-images.githubusercontent.com/21304781/41308540-73df3e6c-6e7c-11e8-8d0c-b81df34d21cb.png">

TODO: 
- make SMS work
- the flows before the task `zeige rechnung` require a mapper for now -> this can be fixed as soon as https://github.com/process-engine/process_engine/issues/101 is resolved.
- rename lower `zeige rechnung` to `sende sms`